### PR TITLE
Add Raspberry Pi serial control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Autonomous Vehicle Control
+
+This repository contains an Arduino sketch for controlling a tank-style vehicle via an L298N motor driver. The sketch now supports commands sent from a Raspberry Pi (or any computer) over a serial connection.
+
+## Arduino Firmware
+
+The file [`tank_ir_control/tank_ir_control.ino`](tank_ir_control/tank_ir_control.ino) listens for simple text commands on the USB serial port:
+
+- `F` – move forward
+- `B` – move backward
+- `L` – turn left
+- `R` – turn right
+- `S` – stop
+- `V<0-255>` – set motor speed, e.g. `V180`
+
+IR remote commands from the original project continue to work.
+
+## Raspberry Pi Example
+
+Use the provided `pi_serial_controller.py` script to send commands from a Raspberry Pi:
+
+```bash
+pip install pyserial
+python pi_serial_controller.py
+```
+
+The script opens `/dev/ttyACM0` at 115200 baud. Adjust the port if your Arduino appears elsewhere.
+
+Once running, type commands like `F`, `V150`, or `S` and press Enter to control the vehicle.
+
+## Hardware Connection
+
+Connect the Raspberry Pi to the Arduino via USB or a direct TX/RX serial connection (ensure common ground). The Arduino drives the motors through an L298N driver board.
+

--- a/pi_serial_controller.py
+++ b/pi_serial_controller.py
@@ -1,0 +1,17 @@
+import serial
+
+def main():
+    # Update '/dev/ttyACM0' to match the port your Arduino uses.
+    with serial.Serial('/dev/ttyACM0', 115200, timeout=1) as ser:
+        print("Enter commands: F, B, L, R, S or V<0-255>")
+        while True:
+            try:
+                cmd = input('> ').strip()
+            except EOFError:
+                break
+            if not cmd:
+                continue
+            ser.write((cmd + '\n').encode('utf-8'))
+
+if __name__ == '__main__':
+    main()

--- a/tank_ir_control/tank_ir_control.ino
+++ b/tank_ir_control/tank_ir_control.ino
@@ -12,7 +12,7 @@ const int IN4 = 11;  // Control pin 2 for motor B
 const int IR_PIN = 3;
 
 // Motor speed (0-255)
-const int MOTOR_SPEED = 255;
+int motorSpeed = 255;
 
 // IR codes (replace with codes from your own remote)
 #define IR_FORWARD  0x4233
@@ -35,6 +35,12 @@ void setup() {
 }
 
 void loop() {
+  if (Serial.available()) {
+    String command = Serial.readStringUntil('\n');
+    command.trim();
+    handleCommand(command);
+  }
+
   if (IrReceiver.decode()) {
     uint32_t code = IrReceiver.decodedIRData.decodedRawData;
     Serial.print(F("Received code: 0x"));
@@ -68,9 +74,33 @@ void loop() {
   }
 }
 
+void handleCommand(const String &command) {
+  if (command == "F") {
+    Serial.println(F("Command: FORWARD"));
+    moveForward();
+  } else if (command == "B") {
+    Serial.println(F("Command: BACKWARD"));
+    moveBackward();
+  } else if (command == "L") {
+    Serial.println(F("Command: LEFT"));
+    turnLeft();
+  } else if (command == "R") {
+    Serial.println(F("Command: RIGHT"));
+    turnRight();
+  } else if (command == "S") {
+    Serial.println(F("Command: STOP"));
+    stopMotors();
+  } else if (command.startsWith("V")) {
+    int spd = command.substring(1).toInt();
+    motorSpeed = constrain(spd, 0, 255);
+    Serial.print(F("Speed set to "));
+    Serial.println(motorSpeed);
+  }
+}
+
 void moveForward() {
-  analogWrite(ENA, MOTOR_SPEED);
-  analogWrite(ENB, MOTOR_SPEED);
+  analogWrite(ENA, motorSpeed);
+  analogWrite(ENB, motorSpeed);
   digitalWrite(IN1, HIGH);
   digitalWrite(IN2, LOW);
   digitalWrite(IN3, HIGH);
@@ -78,8 +108,8 @@ void moveForward() {
 }
 
 void moveBackward() {
-  analogWrite(ENA, MOTOR_SPEED);
-  analogWrite(ENB, MOTOR_SPEED);
+  analogWrite(ENA, motorSpeed);
+  analogWrite(ENB, motorSpeed);
   digitalWrite(IN1, LOW);
   digitalWrite(IN2, HIGH);
   digitalWrite(IN3, LOW);
@@ -87,8 +117,8 @@ void moveBackward() {
 }
 
 void turnLeft() {
-  analogWrite(ENA, MOTOR_SPEED);
-  analogWrite(ENB, MOTOR_SPEED);
+  analogWrite(ENA, motorSpeed);
+  analogWrite(ENB, motorSpeed);
   digitalWrite(IN1, LOW);
   digitalWrite(IN2, HIGH);
   digitalWrite(IN3, HIGH);
@@ -96,8 +126,8 @@ void turnLeft() {
 }
 
 void turnRight() {
-  analogWrite(ENA, MOTOR_SPEED);
-  analogWrite(ENB, MOTOR_SPEED);
+  analogWrite(ENA, motorSpeed);
+  analogWrite(ENB, motorSpeed);
   digitalWrite(IN1, HIGH);
   digitalWrite(IN2, LOW);
   digitalWrite(IN3, LOW);


### PR DESCRIPTION
## Summary
- Add serial command interface to Arduino firmware for motor control
- Provide Python script and README for sending commands from a Raspberry Pi

## Testing
- `python -m py_compile pi_serial_controller.py`
- `arduino-cli compile tank_ir_control/tank_ir_control.ino` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6892a02a49288327aa8f765157f34c50