### PR TITLE
Add blue object tracking script using USB camera

### DIFF
--- a/blue_object_tracker.py
+++ b/blue_object_tracker.py
@@ -1,0 +1,40 @@
+import cv2
+import numpy as np
+
+
+def main():
+    """Track blue objects from a USB camera and draw a red bounding box."""
+    cap = cv2.VideoCapture(0)
+    if not cap.isOpened():
+        raise RuntimeError("Could not open video device")
+
+    # Define blue color range in HSV
+    lower_blue = np.array([100, 150, 50])
+    upper_blue = np.array([140, 255, 255])
+
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+
+        hsv = cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
+        mask = cv2.inRange(hsv, lower_blue, upper_blue)
+        mask = cv2.erode(mask, None, iterations=2)
+        mask = cv2.dilate(mask, None, iterations=2)
+
+        contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        if contours:
+            c = max(contours, key=cv2.contourArea)
+            x, y, w, h = cv2.boundingRect(c)
+            cv2.rectangle(frame, (x, y), (x + w, y + h), (0, 0, 255), 2)
+
+        cv2.imshow('Blue Object Tracker', frame)
+        if cv2.waitKey(1) & 0xFF == ord('q'):
+            break
+
+    cap.release()
+    cv2.destroyAllWindows()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- Add `blue_object_tracker.py` to detect blue objects from a USB camera and highlight them with a red bounding box.

## Testing
- `python -m py_compile blue_object_tracker.py`


------
https://chatgpt.com/codex/tasks/task_e_6892a8b4e6a08327bac787e7eba4cfcf